### PR TITLE
[UPDATE] WebSocket API 리턴데이터 수정

### DIFF
--- a/src/main/java/kr/omen/pico/controller/ChatMessageController.java
+++ b/src/main/java/kr/omen/pico/controller/ChatMessageController.java
@@ -22,9 +22,9 @@ public class ChatMessageController {
     private final ChatMessageService chatMessageService;
 
     @GetMapping("/chatmessage/{chatroomidx}")
-    public ResponseDTO.ChatMessageListResponse findAllMessage(@PathVariable Long chatroomidx){
+    public List<ChatMessageDTO.Card> findAllMessage(@PathVariable Long chatroomidx){
         List<ChatMessageDTO.Card> chatMessageList = chatMessageService.findMessageListByChatRoom(chatroomidx);
-        return new ResponseDTO.ChatMessageListResponse(chatMessageList);
+        return chatMessageList;
     }
 
     @MessageMapping("/sendTo/{roomIdx}/{message}/{token}")
@@ -32,9 +32,8 @@ public class ChatMessageController {
                      @DestinationVariable("message") String message,
                      @DestinationVariable("token") String token) throws Exception{
 
-        ChatMessage chatMessage = chatMessageService.sendMessage(roomIdx,message,token);
-        ResponseDTO.chatMessageResponse dto = new ResponseDTO.chatMessageResponse(chatMessage);
-        simpMessagingTemplate.convertAndSend("/topics/sendTo/"+roomIdx,dto.toString());
+        ChatMessageDTO.Card messageCard = chatMessageService.sendMessage(roomIdx,message,token);
+        simpMessagingTemplate.convertAndSend("/topics/sendTo/1",messageCard);
     }
 
     @MessageMapping("/Template")

--- a/src/main/java/kr/omen/pico/controller/ReviewController.java
+++ b/src/main/java/kr/omen/pico/controller/ReviewController.java
@@ -63,9 +63,9 @@ public class ReviewController {
 //    photographerIdx userIdx로 찾아오기
 //    @GetMapping("/review/select/{photographerIdx}")
     @GetMapping("/reviewList/{userIdx}")
-    public ResponseDTO.reviewListResponse findAllByPhotographer(@PathVariable Long userIdx) {
+    public List<ReviewDTO.Card> findAllByPhotographer(@PathVariable Long userIdx) {
 
-        List<ReviewDTO.Card> reviewList = reviewService.reviewListByPhotographer(userIdx);
-        return new ResponseDTO.reviewListResponse(reviewList);
+        return reviewService.reviewListByPhotographer(userIdx);
+//        return new ResponseDTO.reviewListResponse(reviewList);
     }
 }

--- a/src/main/java/kr/omen/pico/domain/Photographer.java
+++ b/src/main/java/kr/omen/pico/domain/Photographer.java
@@ -2,10 +2,7 @@ package kr.omen.pico.domain;
 
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -29,6 +26,7 @@ public class Photographer {
     private Boolean hasStudio;
 
     @Column
+    @Setter
     private Float grade;
 
     @Column(length = 100)

--- a/src/main/java/kr/omen/pico/domain/dto/ResponseDTO.java
+++ b/src/main/java/kr/omen/pico/domain/dto/ResponseDTO.java
@@ -1,6 +1,8 @@
 package kr.omen.pico.domain.dto;
 
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.omen.pico.domain.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src/main/java/kr/omen/pico/service/ChatMessageService.java
+++ b/src/main/java/kr/omen/pico/service/ChatMessageService.java
@@ -27,7 +27,7 @@ public class ChatMessageService {
 
 
     @Transactional
-    public ChatMessage sendMessage(Long roomIdx,String message,String token) {
+    public ChatMessageDTO.Card sendMessage(Long roomIdx,String message,String token) {
         Authentication Test = tokenProvider.getAuthentication(token);
         ChatMessage chatMessage = null;
         ChatRoom chatRoom = chatRoomRepository.findById(roomIdx).get();
@@ -40,7 +40,8 @@ public class ChatMessageService {
                 .user(user)
                 .message(message)
                 .build());
-        return chatMessage;
+        return new ChatMessageDTO.Card(chatMessage, user);
+//        return chatMessage;
     }
 
     public List<ChatMessageDTO.Card> findMessageListByChatRoom(Long chatroomidx) {

--- a/src/main/java/kr/omen/pico/service/ReviewService.java
+++ b/src/main/java/kr/omen/pico/service/ReviewService.java
@@ -8,6 +8,7 @@ import kr.omen.pico.domain.Apply;
 import kr.omen.pico.domain.Photographer;
 import kr.omen.pico.domain.Review;
 import kr.omen.pico.domain.User;
+import kr.omen.pico.domain.dto.PhotographerDTO;
 import kr.omen.pico.domain.dto.ReviewDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -57,6 +58,12 @@ public class ReviewService {
             if (apply.getStatus().equals(5) && estimateUser == tokenUser) {
                 apply.update(6);
                 review = reviewRepository.save(new Review(tokenUser, photographer, dto.getCreated(), dto.getContent(), dto.getGrade()));
+
+                // 리뷰 작성 후 작가 정보 수정
+                // 임의로 @Setter 사용
+                Float newGradeAverage = gradeAverage(photographer.getPhotographerIdx());
+                photographer.setGrade(newGradeAverage);
+                photographerRepository.save(photographer);
             } else if (apply.getStatus()==6) {
                 System.out.println("이미 리뷰를 작성하였습니다.");
             } else {


### PR DESCRIPTION
### 수정사항
---
##### `GET` `/chatmessage/{chatRoomIdx}`
  - 리턴타입을 `List<ChatMessageDTO.Card>` 로 바꿈
  - 기존에는 리스트를 다시 오브젝트로 담아뒀었는데 바로 리스트로 받는게 처리가 더 편리함

##### `MessageMapping` `/sendTo/{roomIdx}/{message}/{token}`
  - 리턴 타입을 `ChatMessageDTO.Card` 로 맞춤
  - 위에 채팅룸 메시지 내용을 전부 가져오는것과 동일한 형태의 JSON 오브젝트로 받아와야 렌더 처리가 가능
  - toString() 할 필요 없이 DTO 객체를 바로 처리헐 수 있게 클라이언트에서 처리함